### PR TITLE
Create a directory for azhlf tool to be cloned into, rather then curr…

### DIFF
--- a/azhlfToolSetup.sh
+++ b/azhlfToolSetup.sh
@@ -3,6 +3,8 @@
 echo
 echo "===> Cloning azhlf Tool ..."
 echo
+mkdir -p azhlf
+cd azhlf
 git init
 git config core.sparsecheckout true
 echo "azhlfTool" > .git/info/sparse-checkout


### PR DESCRIPTION
…ent working directory

Currently when a user follows the instructions for using the service the remote repository will be cloned into their current working directory which is messy.

Page 25 of the docs PDF will also need to be updated to read:

```
curl https://raw.githubusercontent.com/Azure/Hyperledger-Fabric-on-Azure-KubernetesService/master/azhlfToolSetup.sh | bash
cd azhlf/azhlfTool
npm install
npm run setup
```